### PR TITLE
Fix seeding message

### DIFF
--- a/AIRPORT_MANAGER/management/commands/seed_data.py
+++ b/AIRPORT_MANAGER/management/commands/seed_data.py
@@ -118,4 +118,4 @@ class Command(BaseCommand):
                 member=random.choice(crew_members)
             )
 
-        self.stdout.write(self.style.SUCCESS("✅ Seeding complete! 100 users, 100 crew, 50 flights, 100 airports, etc."))
+        self.stdout.write(self.style.SUCCESS("✅ Seeding complete! 100 users, 20 crews, 50 flights, 100 airports, etc."))

--- a/AIRPORT_MANAGER/management/commands/seed_with_custom_user.py
+++ b/AIRPORT_MANAGER/management/commands/seed_with_custom_user.py
@@ -124,4 +124,4 @@ class Command(BaseCommand):
                 member=random.choice(crew_members)
             )
 
-        self.stdout.write(self.style.SUCCESS("✅ Seeding complete! 100 users, 100 crew, 50 flights, 100 airports, etc."))
+        self.stdout.write(self.style.SUCCESS("✅ Seeding complete! 100 users, 20 crews, 50 flights, 100 airports, etc."))


### PR DESCRIPTION
## Summary
- update success message in seed commands to show 20 crews instead of 100 crew

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6840231e91bc832dbe322985b973b487