### PR TITLE
Fix comment typo in tests

### DIFF
--- a/AIRPORT_MANAGER/tests/test_operator_flight_views.py
+++ b/AIRPORT_MANAGER/tests/test_operator_flight_views.py
@@ -79,7 +79,7 @@ class OperatorFlightViewTests(TestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertGreaterEqual(len(response.data), 2)
 
-    #Преглеждане и модифициране на плети
+    #Преглеждане и модифициране на полети
     def test_operator_can_view_flight_details(self):
         response = self.client.get(f"/api/flights/{self.flight1.id}/")
         self.assertEqual(response.status_code, status.HTTP_200_OK)


### PR DESCRIPTION
## Summary
- correct spelling in operator flight view tests

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_684023238a5c832d8626ff0ee10515eb